### PR TITLE
HSEARCH-2996 Upgrade Elasticsearch dependencies to 5.6.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,11 +8,11 @@
     <url>https://github.com/hibernate/elasticsearch-client-jbossmodules</url>
     <description>Distribution of Elasticsearch Client packaged into JBoss Modules</description>
     <packaging>pom</packaging>
-    <version>5.6.5-SNAPSHOT</version>
+    <version>5.6.6-SNAPSHOT</version>
     <inceptionYear>2017</inceptionYear>
 
     <properties>
-        <version.elasticsearch>5.6.5</version.elasticsearch>
+        <version.elasticsearch>5.6.6</version.elasticsearch>
         <!-- This should match the major.minor of the Elasticsearch version, optionally revisioned with module micro fixes -->
         <slot.simple.id>5.6</slot.simple.id>
         <slot.full.id>${version.elasticsearch}</slot.full.id>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <url>https://github.com/hibernate/elasticsearch-client-jbossmodules</url>
     <description>Distribution of Elasticsearch Client packaged into JBoss Modules</description>
     <packaging>pom</packaging>
-    <version>5.6.6-SNAPSHOT</version>
+    <version>5.6.5-SNAPSHOT</version>
     <inceptionYear>2017</inceptionYear>
 
     <properties>


### PR DESCRIPTION
HSEARCH-2996 - Upgrade Elasticsearch dependencies to 5.6.6

https://hibernate.atlassian.net/browse/HSEARCH-2996

https://github.com/hibernate/hibernate-search/pull/1617
